### PR TITLE
Add ESM build output for Vite 8 compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,9 +3,17 @@
   "version": "0.4.3",
   "description": "Tree select hierarchical component for Vue 3",
   "main": "dist/vue3-treeselect.cjs.min.js",
+  "module": "dist/vue3-treeselect.esm.min.js",
   "unpkg": "dist/vue3-treeselect.umd.min.js",
   "css": "dist/vue3-treeselect.min.css",
   "style": "dist/vue3-treeselect.min.css",
+  "exports": {
+    ".": {
+      "import": "./dist/vue3-treeselect.esm.min.js",
+      "require": "./dist/vue3-treeselect.cjs.min.js"
+    },
+    "./dist/*": "./dist/*"
+  },
   "author": "zanmato",
   "scripts": {
     "prepare": "npm run build-library",

--- a/webpack.lib.config.js
+++ b/webpack.lib.config.js
@@ -91,5 +91,18 @@ module.exports = [
       libraryTarget: "umd",
       filename: "vue3-treeselect.umd.min.js"
     }
+  },
+  {
+    ...baseConfig,
+    target: ["web", "es2020"],
+    experiments: { outputModule: true },
+    externals: [nodeExternals({ importType: "module" })],
+    output: {
+      path: path.join(__dirname, "dist/"),
+      library: { type: "module" },
+      filename: "vue3-treeselect.esm.min.js",
+      module: true,
+      environment: { module: true }
+    }
   }
 ];


### PR DESCRIPTION
## Summary
- Adds an ESM module build target to the webpack library config
- Adds `module` and `exports` fields to `package.json` for proper ESM resolution

## Problem
Vite 8 switched from esbuild to Rolldown for dependency pre-bundling. Rolldown does not synthesize a `default` export from CJS modules, so `import Treeselect from '@zanmato/vue3-treeselect'` breaks with:

```
SyntaxError: The requested module '...vue3-treeselect.cjs.min.js' does not provide an export named 'default'
```

Related issue: #14

## Changes
- **`webpack.lib.config.js`**: Added a third build target producing `vue3-treeselect.esm.min.js` with `library.type: "module"`, `experiments.outputModule: true`, and `target: ["web", "es2020"]`
- **`package.json`**: Added `"module"` field pointing to the ESM build, and `"exports"` map with `"import"` and `"require"` conditions

## Test plan
- [ ] `npm run build-library` produces `dist/vue3-treeselect.esm.min.js` alongside existing CJS and UMD builds
- [ ] ESM build contains proper `export` statements (no `module.exports`)
- [ ] Existing CJS and UMD builds are unchanged
- [ ] Works with Vite 8 projects using `import Treeselect from '@zanmato/vue3-treeselect'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)